### PR TITLE
Fix error with cd

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,7 @@ do
   cd $(dirname ${dir})
   go mod download
   go mod tidy
+  cd "${GITHUB_WORKSPACE}"
 done
 
 if git diff --exit-code


### PR DESCRIPTION
I encountered an error in my private project with the following message (project name is dummy) 

```console
/entrypoint.sh: line 17: cd: ./subproject2: No such file or directory
```

https://github.com/at-wat/go-sum-fix-action/blob/v0.0.0/entrypoint.sh#L17

Each `dir` is a relative path from project root, so each `cd $(dirname ${dir})` should be executed on the root directory.
