### PR TITLE
Add workspace to safe directories

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ fi
 
 set -eu
 
+git config --global --add safe.directory ${GITHUB_WORKSPACE}
 if [ ! "$(git show HEAD --pretty=format:%ae -s)" = "bot@renovateapp.com" ]
 then
   echo "HEAD commit author is not Renovate Bot" >&2


### PR DESCRIPTION
After recent upgrade of Git, the action seems not to work as expected by following error 
So I added the suggested command to entrypoint.sh

```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
HEAD commit author is not Renovate Bot
```

ref: https://github.com/actions/checkout/issues/760
ref: https://github.blog/2022-04-12-git-security-vulnerability-announced/